### PR TITLE
Pin lodash-node below 3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "eventemitter3": "^0.1.5",
-    "lodash-node": "^3.0.1",
+    "lodash-node": "3.8.x",
     "object-path": "^0.6.0"
   },
   "jshintConfig": {


### PR DESCRIPTION
`lodash-node 3.9` breaks in the browser (it wants `root` to exist).  A temporary fix is to pin the version below 3.9 (3.8.x).  The real fix is to change the deps to `lodash` instead of `lodash-node`.

`lodash-node` is deprecated and, was never intended to be used in the browser in the first place.  It's been working by accident up to this version.
